### PR TITLE
Server-side data fetching for instant page loads

### DIFF
--- a/convex/cinemas.ts
+++ b/convex/cinemas.ts
@@ -6,6 +6,7 @@
 
 import { query, mutation } from "./_generated/server";
 import { v } from "convex/values";
+import { DateTime } from "luxon";
 import { sortCinemasByDistance } from "./lib/distance";
 
 // Schema for cinema creation
@@ -102,13 +103,16 @@ export const getCinemasByMovieId = query({
     userLon: v.optional(v.float64()),
   },
   handler: async (ctx, { movieExternalId, userLat, userLon }) => {
-    // Find all events for this movie
-    const events = await ctx.db
+    const today = DateTime.now().toFormat("yyyy-MM-dd");
+
+    // Find current/future events for this movie
+    const allEvents = await ctx.db
       .query("movieEvents")
       .withIndex("by_filmExternalId", (q) =>
         q.eq("filmExternalId", movieExternalId),
       )
       .collect();
+    const events = allEvents.filter((e) => e.businessDay >= today);
 
     // Get unique cinema external IDs
     const cinemaExternalIds = [

--- a/src/app/_components/cinema.tsx
+++ b/src/app/_components/cinema.tsx
@@ -112,15 +112,26 @@ export function CinemaDetailsSkeleton() {
   );
 }
 
-export default function Cinema({ cinemaId }: { cinemaId: string }) {
-  const cinema = useQuery(api.cinemas.getCinemaById, {
+type CinemaInitialData = NonNullable<ReturnType<typeof useQuery<typeof api.cinemas.getCinemaById>>>;
+type EventsInitialData = NonNullable<ReturnType<typeof useQuery<typeof api.movieEvents.getEventsByCinemaToday>>>;
+
+type CinemaProps = {
+  cinemaId: string;
+  initialCinema?: CinemaInitialData | null;
+  initialEvents?: EventsInitialData | null;
+};
+
+export default function Cinema({ cinemaId, initialCinema, initialEvents }: CinemaProps) {
+  const liveCinema = useQuery(api.cinemas.getCinemaById, {
     externalId: parseInt(cinemaId),
   });
+  const cinema = liveCinema ?? initialCinema;
   const isLoading = cinema === undefined;
 
-  const movieEvents = useQuery(api.movieEvents.getEventsByCinemaToday, {
+  const liveEvents = useQuery(api.movieEvents.getEventsByCinemaToday, {
     cinemaExternalId: parseInt(cinemaId),
   });
+  const movieEvents = liveEvents ?? initialEvents;
 
   const { movies, grouped } = useMemo(() => {
     if (!movieEvents) return { movies: [] as TransformedMovie[], grouped: {} as Record<string, TransformedMovieEvent[]> };

--- a/src/app/_components/movie-showtimes.tsx
+++ b/src/app/_components/movie-showtimes.tsx
@@ -11,6 +11,7 @@ import {
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import ShowtimeGrid from "./showtime-grid";
+import { Skeleton } from "~/components/ui/skeleton";
 import { useLocation } from "~/hooks/use-location";
 
 // Type guard to check if cinema has distance property
@@ -39,6 +40,15 @@ export default function MovieShowtimes({ movieId, movieLink }: { movieId: string
     }
   }, [selectedCinema, cinemas]);
 
+  if (!cinemas) {
+    return (
+      <div data-testid="movie-showtimes" className="w-full space-y-6">
+        <Skeleton className="h-10 w-full sm:w-64 rounded" />
+        <Skeleton className="h-32 w-full rounded" />
+      </div>
+    );
+  }
+
   return (
     <div data-testid="movie-showtimes" className="w-full space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row">
@@ -48,7 +58,7 @@ export default function MovieShowtimes({ movieId, movieLink }: { movieId: string
               <SelectValue placeholder="Select Cinema" />
             </SelectTrigger>
             <SelectContent>
-              {cinemas?.map((cinema) => (
+              {cinemas.map((cinema) => (
                 <SelectItem key={cinema.externalId} value={cinema.externalId.toString()}>
                   {cinema.displayName}
                   {hasDistance(cinema) && (

--- a/src/app/_components/movie.tsx
+++ b/src/app/_components/movie.tsx
@@ -8,6 +8,8 @@ import { api } from "../../../convex/_generated/api";
 
 import { DateTime } from "luxon";
 import { useState, useEffect } from "react";
+import { notFound } from "next/navigation";
+import type { Doc } from "../../../convex/_generated/dataModel";
 
 import MovieShowtimes from "./movie-showtimes";
 import { Skeleton } from "~/components/ui/skeleton";
@@ -48,8 +50,9 @@ export function MovieDetailsSkeleton() {
   );
 }
 
-export default function Movie({ movieId }: { movieId: string }) {
-  const movie = useQuery(api.movies.getMovieById, { externalId: movieId });
+export default function Movie({ movieId, initialData }: { movieId: string; initialData?: Doc<"movies"> | null }) {
+  const liveMovie = useQuery(api.movies.getMovieById, { externalId: movieId });
+  const movie = liveMovie ?? initialData;
   const isLoading = movie === undefined;
   const [imgSrc, setImgSrc] = useState("/noposter.png");
   const { requestLocation } = useLocation();
@@ -62,6 +65,10 @@ export default function Movie({ movieId }: { movieId: string }) {
 
   if (isLoading) {
     return <MovieDetailsSkeleton />;
+  }
+
+  if (!movie) {
+    notFound();
   }
 
   return (
@@ -88,7 +95,7 @@ export default function Movie({ movieId }: { movieId: string }) {
             <h1 data-testid="movie-title" className="text-3xl font-bold">{movie?.name}</h1>
             <div data-testid="movie-release-date-badge" className="flex items-center gap-2">
               <Badge variant="outline">
-                {DateTime.fromISO(movie!.releaseDate).toFormat("d MMM yyyy")}
+                {DateTime.fromISO(movie.releaseDate).toFormat("d MMM yyyy")}
               </Badge>
             </div>
           </div>
@@ -100,7 +107,7 @@ export default function Movie({ movieId }: { movieId: string }) {
             </div>
             <div data-testid="movie-release-date" className="flex items-center">
               <Calendar className="mr-1 h-4 w-4" />
-              {DateTime.fromISO(movie!.releaseDate).toFormat("d MMM yyyy")}
+              {DateTime.fromISO(movie.releaseDate).toFormat("d MMM yyyy")}
             </div>
           </div>
 

--- a/src/app/_components/search.tsx
+++ b/src/app/_components/search.tsx
@@ -54,8 +54,11 @@ function MoviesSearchSkeleton() {
   );
 }
 
-export default function SearchResults({ query }: { query: string }) {
-  const results = useQuery(api.movies.searchMovies, { searchTerm: query });
+type SearchResult = NonNullable<ReturnType<typeof useQuery<typeof api.movies.searchMovies>>>;
+
+export default function SearchResults({ query, initialResults }: { query: string; initialResults?: SearchResult }) {
+  const liveResults = useQuery(api.movies.searchMovies, { searchTerm: query });
+  const results = liveResults ?? initialResults;
   const isLoading = results === undefined;
 
   if (isLoading) {

--- a/src/app/cinemas/[id]/loading.tsx
+++ b/src/app/cinemas/[id]/loading.tsx
@@ -1,3 +1,9 @@
+import { CinemaDetailsSkeleton } from "~/app/_components/cinema";
+
 export default function Loading() {
-  return null;
+  return (
+    <div className="bg-background min-h-screen">
+      <CinemaDetailsSkeleton />
+    </div>
+  );
 }

--- a/src/app/cinemas/[id]/page.tsx
+++ b/src/app/cinemas/[id]/page.tsx
@@ -1,5 +1,22 @@
 import Link from "next/link";
+import { fetchQuery } from "convex/nextjs";
+import { unstable_cache } from "next/cache";
+import { api } from "../../../../convex/_generated/api";
 import Cinema from "~/app/_components/cinema";
+
+const getCachedCinema = unstable_cache(
+  async (externalId: number) =>
+    fetchQuery(api.cinemas.getCinemaById, { externalId }),
+  ["cinema-detail"],
+  { revalidate: 60 },
+);
+
+const getCachedCinemaEvents = unstable_cache(
+  async (cinemaExternalId: number) =>
+    fetchQuery(api.movieEvents.getEventsByCinemaToday, { cinemaExternalId }),
+  ["cinema-events"],
+  { revalidate: 60 },
+);
 
 export default async function CinemaPage({
   params,
@@ -7,6 +24,11 @@ export default async function CinemaPage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const cinemaId = parseInt(id);
+  const [initialCinema, initialEvents] = await Promise.all([
+    getCachedCinema(cinemaId),
+    getCachedCinemaEvents(cinemaId),
+  ]);
 
   return (
     <div className="bg-background min-h-screen">
@@ -20,7 +42,11 @@ export default async function CinemaPage({
         </div>
       </header>
 
-      <Cinema cinemaId={id} />
+      <Cinema
+        cinemaId={id}
+        initialCinema={initialCinema}
+        initialEvents={initialEvents}
+      />
     </div>
   );
 }

--- a/src/app/movies/[id]/loading.tsx
+++ b/src/app/movies/[id]/loading.tsx
@@ -1,3 +1,9 @@
+import { MovieDetailsSkeleton } from "~/app/_components/movie";
+
 export default function Loading() {
-  return null;
+  return (
+    <div className="bg-background min-h-screen">
+      <MovieDetailsSkeleton />
+    </div>
+  );
 }

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -1,4 +1,14 @@
+import { fetchQuery } from "convex/nextjs";
+import { unstable_cache } from "next/cache";
+import { api } from "../../../../convex/_generated/api";
 import Movie from "~/app/_components/movie";
+
+const getCachedMovie = unstable_cache(
+  async (externalId: string) =>
+    fetchQuery(api.movies.getMovieById, { externalId }),
+  ["movie-detail"],
+  { revalidate: 60 },
+);
 
 export default async function MoviePage({
   params,
@@ -6,10 +16,11 @@ export default async function MoviePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
+  const initialMovie = await getCachedMovie(id);
 
   return (
     <div className="bg-background min-h-screen">
-      <Movie movieId={id} />
+      <Movie movieId={id} initialData={initialMovie} />
     </div>
   );
 }

--- a/src/app/movies/page.tsx
+++ b/src/app/movies/page.tsx
@@ -1,4 +1,5 @@
 import { fetchQuery } from "convex/nextjs";
+import { unstable_cache } from "next/cache";
 import { api } from "../../../convex/_generated/api";
 import MoviesInfiniteList from "~/app/_components/movies-infinite-list";
 
@@ -9,12 +10,19 @@ export const metadata = {
 
 const MOVIES_PER_PAGE = 24;
 
+const getCachedMovies = unstable_cache(
+  async () =>
+    fetchQuery(api.movies.getAllMovies, {
+      orderByPopularity: "desc",
+      limit: MOVIES_PER_PAGE,
+      offset: 0,
+    }),
+  ["movies-list"],
+  { revalidate: 60 },
+);
+
 export default async function MoviesPage() {
-  const initialMovies = await fetchQuery(api.movies.getAllMovies, {
-    orderByPopularity: "desc",
-    limit: MOVIES_PER_PAGE,
-    offset: 0,
-  });
+  const initialMovies = await getCachedMovies();
 
   return (
     <div className="container mx-auto px-4 py-8">

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -46,7 +46,7 @@ export default async function SearchPage({
         </div>
       </header>
 
-      <SearchResults query={query!} initialResults={initialResults} />
+      <SearchResults query={query ?? ""} initialResults={initialResults} />
     </div>
   );
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -2,6 +2,8 @@ import Link from "next/link";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import { Search } from "lucide-react";
+import { fetchQuery } from "convex/nextjs";
+import { api } from "../../../convex/_generated/api";
 import SearchResults from "~/app/_components/search";
 
 export default async function SearchPage({
@@ -10,6 +12,9 @@ export default async function SearchPage({
   searchParams: Promise<{ query?: string }>;
 }) {
   const { query } = await searchParams;
+  const initialResults = query
+    ? await fetchQuery(api.movies.searchMovies, { searchTerm: query })
+    : [];
 
   return (
     <div className="bg-background min-h-screen">
@@ -41,7 +46,7 @@ export default async function SearchPage({
         </div>
       </header>
 
-      <SearchResults query={query!} />
+      <SearchResults query={query!} initialResults={initialResults} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add server-side data fetching with `unstable_cache` + `fetchQuery` for movie detail, cinema detail, movies list, and search pages
- Use `liveData ?? initialData` pattern: SSR data renders instantly, then Convex `useQuery` takes over for real-time reactivity
- Filter `getCinemasByMovieId` to only return cinemas with current/future showtimes
- Restore loading skeletons in `loading.tsx` for proper client-side navigation feedback
- Add `notFound()` handling for non-existent movies

## Test plan
- [x] All 39 Playwright E2E tests pass
- [x] `npm run build` succeeds with no type errors
- [ ] Verify Vercel preview: movie/cinema detail pages load instantly (no skeleton flash on direct navigation)
- [ ] Verify cinema dropdown on movie page only shows cinemas with active showtimes

🤖 Generated with [Claude Code](https://claude.com/claude-code)