### PR TITLE
Server-side prefetch cinemas and showtimes on movie detail page

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: process.env.CI ? "html" : "list",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     extraHTTPHeaders: {

--- a/src/app/_components/movie-showtimes.tsx
+++ b/src/app/_components/movie-showtimes.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   Select,
   SelectContent,
@@ -19,11 +19,23 @@ function hasDistance(cinema: unknown): cinema is { distance: number } {
   return typeof cinema === 'object' && cinema !== null && 'distance' in cinema && typeof (cinema as Record<string, unknown>).distance === 'number';
 }
 
-export default function MovieShowtimes({ movieId, movieLink }: { movieId: string; movieLink?: string }) {
-  const [selectedCinema, setSelectedCinema] = useState<string>("");
+type CinemasResult = NonNullable<ReturnType<typeof useQuery<typeof api.cinemas.getCinemasByMovieId>>>;
+type ShowtimesResult = NonNullable<ReturnType<typeof useQuery<typeof api.movieEvents.getEventsByCinemaAndMovie>>>;
+
+export type MovieShowtimesInitialData = {
+  initialCinemas?: CinemasResult | null;
+  initialShowtimes?: ShowtimesResult | null;
+};
+
+type MovieShowtimesProps = {
+  movieId: string;
+  movieLink?: string;
+} & MovieShowtimesInitialData;
+
+export default function MovieShowtimes({ movieId, movieLink, initialCinemas, initialShowtimes }: MovieShowtimesProps) {
   const { location } = useLocation();
 
-  const cinemas = useQuery(
+  const liveCinemas = useQuery(
     api.cinemas.getCinemasByMovieId,
     {
       movieExternalId: movieId,
@@ -33,12 +45,21 @@ export default function MovieShowtimes({ movieId, movieLink }: { movieId: string
       }),
     }
   );
+  const cinemas = liveCinemas ?? initialCinemas;
 
-  useEffect(() => {
-    if (selectedCinema === "" && cinemas) {
-      setSelectedCinema(cinemas?.[0]?.externalId.toString() ?? "");
-    }
-  }, [selectedCinema, cinemas]);
+  // Initialize selectedCinema from initialCinemas to avoid empty first render
+  const [selectedCinema, setSelectedCinema] = useState<string>(
+    () => initialCinemas?.[0]?.externalId.toString() ?? ""
+  );
+
+  // When live cinemas arrive and nothing is selected, pick the first one
+  if (selectedCinema === "" && cinemas && cinemas.length > 0) {
+    setSelectedCinema(cinemas[0]!.externalId.toString());
+  }
+
+  // Only use initialShowtimes if the selected cinema matches the first cinema
+  const firstCinemaId = initialCinemas?.[0]?.externalId.toString();
+  const showtimesInitial = selectedCinema === firstCinemaId ? initialShowtimes : undefined;
 
   if (!cinemas) {
     return (
@@ -73,7 +94,12 @@ export default function MovieShowtimes({ movieId, movieLink }: { movieId: string
         </div>
       </div>
 
-      <ShowtimeGrid movieId={movieId} cinemaId={selectedCinema} movieLink={movieLink} />
+      <ShowtimeGrid
+        movieId={movieId}
+        cinemaId={selectedCinema}
+        movieLink={movieLink}
+        initialShowtimes={showtimesInitial}
+      />
     </div>
   );
 }

--- a/src/app/_components/movie.tsx
+++ b/src/app/_components/movie.tsx
@@ -11,7 +11,7 @@ import { useState, useEffect } from "react";
 import { notFound } from "next/navigation";
 import type { Doc } from "../../../convex/_generated/dataModel";
 
-import MovieShowtimes from "./movie-showtimes";
+import MovieShowtimes, { type MovieShowtimesInitialData } from "./movie-showtimes";
 import { Skeleton } from "~/components/ui/skeleton";
 import LocationPermissionToast from "./location-permission-dialog";
 import { useLocation } from "~/hooks/use-location";
@@ -50,7 +50,14 @@ export function MovieDetailsSkeleton() {
   );
 }
 
-export default function Movie({ movieId, initialData }: { movieId: string; initialData?: Doc<"movies"> | null }) {
+type MovieProps = {
+  movieId: string;
+  initialData?: Doc<"movies"> | null;
+  initialCinemas?: MovieShowtimesInitialData["initialCinemas"];
+  initialShowtimes?: MovieShowtimesInitialData["initialShowtimes"];
+};
+
+export default function Movie({ movieId, initialData, initialCinemas, initialShowtimes }: MovieProps) {
   const liveMovie = useQuery(api.movies.getMovieById, { externalId: movieId });
   const movie = liveMovie ?? initialData;
   const isLoading = movie === undefined;
@@ -126,7 +133,12 @@ export default function Movie({ movieId, initialData }: { movieId: string; initi
 
           <h2 className="mb-6 text-2xl font-bold">Showtimes</h2>
 
-          <MovieShowtimes movieId={movieId} movieLink={movie?.link} />
+          <MovieShowtimes
+            movieId={movieId}
+            movieLink={movie?.link}
+            initialCinemas={initialCinemas}
+            initialShowtimes={initialShowtimes}
+          />
         </div>
       </div>
 

--- a/src/app/_components/showtime-grid.tsx
+++ b/src/app/_components/showtime-grid.tsx
@@ -4,7 +4,7 @@ import { Badge } from "~/components/ui/badge";
 import { Card, CardContent } from "~/components/ui/card";
 import { MapPin } from "lucide-react";
 import { Clock } from "lucide-react";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../../convex/_generated/api";
 import { Skeleton } from "~/components/ui/skeleton";
@@ -24,45 +24,41 @@ type TransformedMovieEvent = {
   } | null;
 };
 
+type ShowtimeGridProps = {
+  movieId: string;
+  cinemaId: string;
+  movieLink?: string;
+  initialShowtimes?: TransformedMovieEvent[] | null;
+};
+
 export default function ShowtimeGrid({
   movieId,
   cinemaId,
   movieLink,
-}: {
-  movieId: string;
-  cinemaId: string;
-  movieLink?: string;
-}) {
+  initialShowtimes,
+}: ShowtimeGridProps) {
   const [selectedDate, setSelectedDate] = useState<string>("");
-  const [showtimes, setShowtimes] = useState<TransformedMovieEvent[] | null>(
-    null,
-  );
-  const [availableDates, setAvailableDates] = useState<string[]>([]);
 
-  const events = useQuery(api.movieEvents.getEventsByCinemaAndMovie, {
+  const liveEvents = useQuery(api.movieEvents.getEventsByCinemaAndMovie, {
     cinemaExternalId: Number(cinemaId),
     movieExternalId: movieId,
   });
+  const events = liveEvents ?? initialShowtimes;
   const isLoading = events === undefined;
 
-  useEffect(() => {
-    if (events) {
-      setShowtimes(events);
-      setAvailableDates(
-        [...new Set(events.map((event) => event.businessDay))].sort(),
-      );
-    }
-  }, [events]);
+  const showtimes = events ?? null;
+  const availableDates = events
+    ? [...new Set(events.map((event) => event.businessDay))].sort()
+    : [];
 
-  useEffect(() => {
-    if (selectedDate === "") {
-      setSelectedDate(availableDates[0] ?? "");
-    }
-  }, [selectedDate, availableDates]);
+  // Use selectedDate if it's valid, otherwise default to first available date
+  const activeDate = selectedDate && availableDates.includes(selectedDate)
+    ? selectedDate
+    : availableDates[0] ?? "";
 
-  // Filter showtimes by selected date
+  // Filter showtimes by active date
   const filteredShowtimes =
-    showtimes?.filter((showtime) => showtime.businessDay === selectedDate) ??
+    showtimes?.filter((showtime) => showtime.businessDay === activeDate) ??
     [];
 
   return (
@@ -81,13 +77,13 @@ export default function ShowtimeGrid({
           if (date === today) {
             displayText = "Today";
             customClasses =
-              selectedDate === date
+              activeDate === date
                 ? "border-yellow-500 bg-yellow-500 text-black hover:bg-yellow-600"
                 : "border-yellow-500 text-yellow-500 hover:bg-yellow-500/10";
           } else if (date === tomorrow) {
             displayText = "Tomorrow";
             customClasses =
-              selectedDate === date
+              activeDate === date
                 ? "border-purple-500 bg-purple-500 text-white hover:bg-purple-600"
                 : "border-purple-500 text-purple-500 hover:bg-purple-500/10";
           }
@@ -95,7 +91,7 @@ export default function ShowtimeGrid({
           return (
             <Button
               key={date}
-              variant={selectedDate === date ? "default" : "outline"}
+              variant={activeDate === date ? "default" : "outline"}
               onClick={() => setSelectedDate(date)}
               className={`flex items-center gap-2 ${customClasses}`}
             >

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -2,33 +2,9 @@ import { fetchQuery } from "convex/nextjs";
 import { api } from "../../../../convex/_generated/api";
 import Movie from "~/app/_components/movie";
 
-async function getMovie(externalId: string) {
+async function safeQuery<T>(queryFn: () => Promise<T>): Promise<T | null> {
   try {
-    return await fetchQuery(api.movies.getMovieById, { externalId });
-  } catch {
-    return null;
-  }
-}
-
-async function getCinemas(movieExternalId: string) {
-  try {
-    return await fetchQuery(api.cinemas.getCinemasByMovieId, {
-      movieExternalId,
-    });
-  } catch {
-    return null;
-  }
-}
-
-async function getShowtimes(
-  movieExternalId: string,
-  cinemaExternalId: number,
-) {
-  try {
-    return await fetchQuery(api.movieEvents.getEventsByCinemaAndMovie, {
-      movieExternalId,
-      cinemaExternalId,
-    });
+    return await queryFn();
   } catch {
     return null;
   }
@@ -43,14 +19,19 @@ export default async function MoviePage({
 
   // Fetch movie + cinemas in parallel
   const [initialMovie, initialCinemas] = await Promise.all([
-    getMovie(id),
-    getCinemas(id),
+    safeQuery(() => fetchQuery(api.movies.getMovieById, { externalId: id })),
+    safeQuery(() => fetchQuery(api.cinemas.getCinemasByMovieId, { movieExternalId: id })),
   ]);
 
   // Fetch first cinema's showtimes (if cinemas exist)
   const firstCinemaId = initialCinemas?.[0]?.externalId;
   const initialShowtimes = firstCinemaId
-    ? await getShowtimes(id, firstCinemaId)
+    ? await safeQuery(() =>
+        fetchQuery(api.movieEvents.getEventsByCinemaAndMovie, {
+          movieExternalId: id,
+          cinemaExternalId: firstCinemaId,
+        }),
+      )
     : null;
 
   return (

--- a/src/app/movies/[id]/page.tsx
+++ b/src/app/movies/[id]/page.tsx
@@ -1,14 +1,38 @@
 import { fetchQuery } from "convex/nextjs";
-import { unstable_cache } from "next/cache";
 import { api } from "../../../../convex/_generated/api";
 import Movie from "~/app/_components/movie";
 
-const getCachedMovie = unstable_cache(
-  async (externalId: string) =>
-    fetchQuery(api.movies.getMovieById, { externalId }),
-  ["movie-detail"],
-  { revalidate: 60 },
-);
+async function getMovie(externalId: string) {
+  try {
+    return await fetchQuery(api.movies.getMovieById, { externalId });
+  } catch {
+    return null;
+  }
+}
+
+async function getCinemas(movieExternalId: string) {
+  try {
+    return await fetchQuery(api.cinemas.getCinemasByMovieId, {
+      movieExternalId,
+    });
+  } catch {
+    return null;
+  }
+}
+
+async function getShowtimes(
+  movieExternalId: string,
+  cinemaExternalId: number,
+) {
+  try {
+    return await fetchQuery(api.movieEvents.getEventsByCinemaAndMovie, {
+      movieExternalId,
+      cinemaExternalId,
+    });
+  } catch {
+    return null;
+  }
+}
 
 export default async function MoviePage({
   params,
@@ -16,11 +40,27 @@ export default async function MoviePage({
   params: Promise<{ id: string }>;
 }) {
   const { id } = await params;
-  const initialMovie = await getCachedMovie(id);
+
+  // Fetch movie + cinemas in parallel
+  const [initialMovie, initialCinemas] = await Promise.all([
+    getMovie(id),
+    getCinemas(id),
+  ]);
+
+  // Fetch first cinema's showtimes (if cinemas exist)
+  const firstCinemaId = initialCinemas?.[0]?.externalId;
+  const initialShowtimes = firstCinemaId
+    ? await getShowtimes(id, firstCinemaId)
+    : null;
 
   return (
     <div className="bg-background min-h-screen">
-      <Movie movieId={id} initialData={initialMovie} />
+      <Movie
+        movieId={id}
+        initialData={initialMovie}
+        initialCinemas={initialCinemas}
+        initialShowtimes={initialShowtimes}
+      />
     </div>
   );
 }

--- a/tests/not-found.spec.ts
+++ b/tests/not-found.spec.ts
@@ -16,31 +16,17 @@ test.describe('404 / not-found pages', () => {
   test('navigating to a non-existent movie shows not-found state', async ({ page }) => {
     await page.goto('/movies/NONEXISTENT999');
 
-    // The page must not be blank — wait for either:
-    //   (a) the custom 404 heading from not-found.tsx, or
-    //   (b) the movie loading skeleton or an empty movie detail shell.
-    // In all cases the <body> should have meaningful content.
-    await expect(page.locator('body')).not.toBeEmpty();
+    // The client component calls notFound() after useQuery confirms the movie doesn't exist.
+    // Wait for either the 404 page or verify the page isn't blank.
+    await expect(
+      page.getByRole('heading', { name: '404 - Page Not Found' })
+    ).toBeVisible({ timeout: 10000 });
 
-    // Check that we see EITHER the Next.js 404 page text OR the movie page shell.
-    // The not-found boundary renders "404 - Page Not Found".
-    // We allow some time for the client-side query to settle.
-    const notFoundHeading = page.getByRole('heading', { name: '404 - Page Not Found' });
-    const notFoundCount = await notFoundHeading.count();
+    await expect(
+      page.getByText('The page you are looking for might have been removed', { exact: false })
+    ).toBeVisible();
 
-    if (notFoundCount > 0) {
-      // Full 404 page is shown — verify the standard copy and return-home link
-      await expect(notFoundHeading).toBeVisible();
-      await expect(
-        page.getByText('The page you are looking for might have been removed', { exact: false })
-      ).toBeVisible();
-      await expect(page.getByRole('link', { name: 'Return to Home' })).toBeVisible();
-    } else {
-      // The route matched /movies/[id] but the movie was not found.
-      // The component might still show its skeleton or an empty shell.
-      // Assert that the page at minimum has a <main> element (not a blank screen).
-      await expect(page.locator('main')).toBeVisible();
-    }
+    await expect(page.getByRole('link', { name: 'Return to Home' })).toBeVisible();
   });
 
   test('navigating to a non-existent cinema shows not-found state', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Server-side prefetch cinemas and first cinema's showtimes on the movie detail page, eliminating client-side loading waterfall
- Refactored showtime-grid and movie-showtimes to use derived state and initialData props instead of useEffect chains
- Simplified 404 test assertions and switched to list reporter for local Playwright runs

## Test plan
- [ ] Verify movie detail page loads with showtimes visible on first paint (no loading spinner for showtimes)
- [ ] Verify switching cinemas still works and fetches new showtimes client-side
- [ ] Verify 404 page still shows correctly for non-existent movies
- [ ] Run Playwright E2E tests: `npx playwright test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)